### PR TITLE
Use Go 1.12 to fix tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.12
 
 RUN mkdir -p $GOPATH/src/github.com/Percona-Lab/pmm-api-tests
 


### PR DESCRIPTION
```
go test -count=1 -v -race ./... 2>&1 | tee pmm-api-tests-output.txt
?   	github.com/Percona-Lab/pmm-api-tests	[no test files]
flag provided but not defined: -test.count
Usage of /tmp/go-build744474690/b186/inventory.test:
  -pmm.debug
    	Enable debug output [PMM_DEBUG].
  -pmm.run-update-test
    	Run PMM Server update test [PMM_RUN_UPDATE_TEST].
  -pmm.server-insecure-tls
    	Skip PMM Server TLS certificate validation [PMM_SERVER_INSECURE_TLS].
  -pmm.server-url string
    	PMM Server URL [PMM_SERVER_URL]. (default "https://admin:admin@127.0.0.1:8443/")
  -pmm.trace
    	Enable trace output [PMM_TRACE].
FAIL	github.com/Percona-Lab/pmm-api-tests/inventory	0.210s
```

Most likely due to https://golang.org/doc/go1.13#testing:
> Testing flags are now registered in the new Init function, which is invoked by the generated main function for the test. As a result, testing flags are now only registered when running a test binary, and packages that call flag.Parse during package initialization may cause tests to fail.

We should fix it later.