### PR TITLE
PMM-4474 Added RDS exporter agent tests

### DIFF
--- a/inventory/agents_rds_exporter_test.go
+++ b/inventory/agents_rds_exporter_test.go
@@ -1,0 +1,178 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/percona/pmm/api/inventorypb/json/client"
+	"github.com/percona/pmm/api/inventorypb/json/client/agents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	pmmapitests "github.com/Percona-Lab/pmm-api-tests"
+)
+
+func TestRDSExporter(t *testing.T) {
+	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
+
+		genericNodeID := addGenericNode(t, pmmapitests.TestString(t, "")).NodeID
+		require.NotEmpty(t, genericNodeID)
+		defer pmmapitests.RemoveNodes(t, genericNodeID)
+
+		node := addRemoteRDSNode(t, pmmapitests.TestString(t, "Remote node for RDS exporter"))
+		nodeID := node.RemoteRDS.NodeID
+		defer pmmapitests.RemoveNodes(t, nodeID)
+
+		pmmAgent := addPMMAgent(t, genericNodeID)
+		pmmAgentID := pmmAgent.PMMAgent.AgentID
+		defer pmmapitests.RemoveAgents(t, pmmAgentID)
+
+		rdsExporter := addRDSExporter(t, agents.AddRDSExporterBody{
+			NodeID:     nodeID,
+			PMMAgentID: pmmAgentID,
+			CustomLabels: map[string]string{
+				"custom_label_rds_exporter": "rds_exporter",
+			},
+
+			SkipConnectionCheck: true,
+		})
+		agentID := rdsExporter.RDSExporter.AgentID
+		defer pmmapitests.RemoveAgents(t, agentID)
+
+		getAgentRes, err := client.Default.Agents.GetAgent(&agents.GetAgentParams{
+			Body:    agents.GetAgentBody{AgentID: agentID},
+			Context: pmmapitests.Context,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, &agents.GetAgentOK{
+			Payload: &agents.GetAgentOKBody{
+				RDSExporter: &agents.GetAgentOKBodyRDSExporter{
+					NodeID:     nodeID,
+					AgentID:    agentID,
+					PMMAgentID: pmmAgentID,
+					CustomLabels: map[string]string{
+						"custom_label_rds_exporter": "rds_exporter",
+					},
+				},
+			},
+		}, getAgentRes)
+
+		// Test change API.
+		changeRDSExporterOK, err := client.Default.Agents.ChangeRDSExporter(&agents.ChangeRDSExporterParams{
+			Body: agents.ChangeRDSExporterBody{
+				AgentID: agentID,
+				Common: &agents.ChangeRDSExporterParamsBodyCommon{
+					Disable:            true,
+					RemoveCustomLabels: true,
+				},
+			},
+			Context: pmmapitests.Context,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, &agents.ChangeRDSExporterOK{
+			Payload: &agents.ChangeRDSExporterOKBody{
+				RDSExporter: &agents.ChangeRDSExporterOKBodyRDSExporter{
+					NodeID:     nodeID,
+					AgentID:    agentID,
+					PMMAgentID: pmmAgentID,
+					Disabled:   true,
+				},
+			},
+		}, changeRDSExporterOK)
+
+		changeRDSExporterOK, err = client.Default.Agents.ChangeRDSExporter(&agents.ChangeRDSExporterParams{
+			Body: agents.ChangeRDSExporterBody{
+				AgentID: agentID,
+				Common: &agents.ChangeRDSExporterParamsBodyCommon{
+					Enable: true,
+					CustomLabels: map[string]string{
+						"new_label": "rds_exporter",
+					},
+				},
+			},
+			Context: pmmapitests.Context,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, &agents.ChangeRDSExporterOK{
+			Payload: &agents.ChangeRDSExporterOKBody{
+				RDSExporter: &agents.ChangeRDSExporterOKBodyRDSExporter{
+					NodeID:     nodeID,
+					AgentID:    agentID,
+					PMMAgentID: pmmAgentID,
+					Disabled:   false,
+					CustomLabels: map[string]string{
+						"new_label": "rds_exporter",
+					},
+				},
+			},
+		}, changeRDSExporterOK)
+	})
+
+	t.Run("AddNodeIDEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		genericNodeID := addGenericNode(t, pmmapitests.TestString(t, "")).NodeID
+		require.NotEmpty(t, genericNodeID)
+		defer pmmapitests.RemoveNodes(t, genericNodeID)
+
+		pmmAgent := addPMMAgent(t, genericNodeID)
+		pmmAgentID := pmmAgent.PMMAgent.AgentID
+		defer pmmapitests.RemoveAgents(t, pmmAgentID)
+
+		res, err := client.Default.Agents.AddRDSExporter(&agents.AddRDSExporterParams{
+			Body: agents.AddRDSExporterBody{
+				NodeID:     "",
+				PMMAgentID: pmmAgentID,
+			},
+			Context: pmmapitests.Context,
+		})
+		pmmapitests.AssertAPIErrorf(t, err, 400, codes.InvalidArgument, "invalid field NodeId: value '' must not be an empty string")
+		if !assert.Nil(t, res) {
+			pmmapitests.RemoveNodes(t, res.Payload.RDSExporter.AgentID)
+		}
+	})
+
+	t.Run("NotExistNodeID", func(t *testing.T) {
+		t.Parallel()
+
+		genericNodeID := addGenericNode(t, pmmapitests.TestString(t, "")).NodeID
+		require.NotEmpty(t, genericNodeID)
+		defer pmmapitests.RemoveNodes(t, genericNodeID)
+
+		pmmAgent := addPMMAgent(t, genericNodeID)
+		pmmAgentID := pmmAgent.PMMAgent.AgentID
+		defer pmmapitests.RemoveAgents(t, pmmAgentID)
+
+		res, err := client.Default.Agents.AddRDSExporter(&agents.AddRDSExporterParams{
+			Body: agents.AddRDSExporterBody{
+				NodeID:     "pmm-node-id",
+				PMMAgentID: pmmAgentID,
+			},
+			Context: pmmapitests.Context,
+		})
+		pmmapitests.AssertAPIErrorf(t, err, 404, codes.NotFound, "Node with ID \"pmm-node-id\" not found.")
+		if !assert.Nil(t, res) {
+			pmmapitests.RemoveAgents(t, res.Payload.RDSExporter.AgentID)
+		}
+	})
+
+	t.Run("NotExistPMMAgentID", func(t *testing.T) {
+		t.Parallel()
+		genericNodeID := addGenericNode(t, pmmapitests.TestString(t, "")).NodeID
+		require.NotEmpty(t, genericNodeID)
+		defer pmmapitests.RemoveNodes(t, genericNodeID)
+
+		res, err := client.Default.Agents.AddRDSExporter(&agents.AddRDSExporterParams{
+			Body: agents.AddRDSExporterBody{
+				NodeID:     "nodeID",
+				PMMAgentID: "pmm-not-exist-server",
+			},
+			Context: pmmapitests.Context,
+		})
+		pmmapitests.AssertAPIErrorf(t, err, 404, codes.NotFound, "Agent with ID \"pmm-not-exist-server\" not found.")
+		if !assert.Nil(t, res) {
+			pmmapitests.RemoveAgents(t, res.Payload.RDSExporter.AgentID)
+		}
+	})
+}

--- a/inventory/helpers.go
+++ b/inventory/helpers.go
@@ -42,6 +42,39 @@ func addRemoteNode(t pmmapitests.TestingT, nodeName string) *nodes.AddRemoteNode
 	res, err := client.Default.Nodes.AddRemoteNode(params)
 	assert.NoError(t, err)
 	require.NotNil(t, res)
+
+	return res.Payload
+}
+
+func addRemoteRDSNode(t pmmapitests.TestingT, nodeName string) *nodes.AddRemoteRDSNodeOKBody {
+	t.Helper()
+
+	params := &nodes.AddRemoteRDSNodeParams{
+		Body: nodes.AddRemoteRDSNodeBody{
+			NodeName: nodeName,
+			Address:  "some-address",
+			Region:   "region",
+		},
+
+		Context: pmmapitests.Context,
+	}
+	res, err := client.Default.Nodes.AddRemoteRDSNode(params)
+	assert.NoError(t, err)
+	require.NotNil(t, res)
+
+	return res.Payload
+}
+
+func addRDSExporter(t pmmapitests.TestingT, body agents.AddRDSExporterBody) *agents.AddRDSExporterOKBody {
+	t.Helper()
+
+	res, err := client.Default.Agents.AddRDSExporter(&agents.AddRDSExporterParams{
+		Body:    body,
+		Context: pmmapitests.Context,
+	})
+	assert.NoError(t, err)
+	require.NotNil(t, res)
+
 	return res.Payload
 }
 


### PR DESCRIPTION
This branch replaces PMM-4474_Add_rds_exporter_agent-B which had merge conflicts. It was easier to implement the new test on top of an up-to-date branch than fixing all the conflicts.

Original PR: https://github.com/Percona-Lab/pmm-api-tests/pull/59

There are errors due yo nginx confix. Ignoring them for the moment
```
--- FAIL: TestAuth/Setup/WebPage (0.02s)
            auth_test.go:105: 
                        Error Trace:    auth_test.go:105
                        Error:          Not equal: 
                                        expected: 200
                                        actual  : 401
                        Test:           TestAuth/Setup/WebPage
                        Messages:       response:
                                        {"code":16,"error":"Unauthorized","message":"Unauthorized"}
            auth_test.go:106: 
                        Error Trace:    auth_test.go:106
                        Error:          Should be true
                        Test:           TestAuth/Setup/WebPage
                        Messages:       {"code":16,"error":"Unauthorized","message":"Unauthorized"}
```
