### PR TITLE
PMM-5448 Tests for new resolutions

### DIFF
--- a/server/settings_test.go
+++ b/server/settings_test.go
@@ -26,7 +26,7 @@ func TestSettings(t *testing.T) {
 		assert.True(t, res.Payload.Settings.TelemetryEnabled)
 		expected := &server.GetSettingsOKBodySettingsMetricsResolutions{
 			Hr: "5s",
-			Mr: "5s",
+			Mr: "10s",
 			Lr: "60s",
 		}
 		assert.Equal(t, expected, res.Payload.Settings.MetricsResolutions)


### PR DESCRIPTION
Default metric resolutions were updated to 5-10-60 s