### PR TITLE
PMM-7819 modify TestXtraDBClusterServer to use HAProxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-openapi/spec v0.19.9 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/percona-platform/saas v0.0.0-20210122115803-1b32ca1828e1
-	github.com/percona/pmm v2.15.2-0.20210405073023-614c31c2cf56+incompatible
+	github.com/percona/pmm v2.15.2-0.20210407110927-4b3756c1d2fe+incompatible
 	github.com/prometheus/client_golang v1.9.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-openapi/spec v0.19.9 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/percona-platform/saas v0.0.0-20210122115803-1b32ca1828e1
-	github.com/percona/pmm v2.15.2-0.20210407110927-4b3756c1d2fe+incompatible
+	github.com/percona/pmm v2.16.1-0.20210420094828-a4ee02c38421+incompatible
 	github.com/prometheus/client_golang v1.9.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,8 @@ github.com/percona/pmm v2.15.2-0.20210405073023-614c31c2cf56+incompatible h1:Usr
 github.com/percona/pmm v2.15.2-0.20210405073023-614c31c2cf56+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/pmm v2.15.2-0.20210407110927-4b3756c1d2fe+incompatible h1:peECGcQ2rYt1eMtJJI4cYFSSysa+bNjDDPoNR4AiJWk=
 github.com/percona/pmm v2.15.2-0.20210407110927-4b3756c1d2fe+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
+github.com/percona/pmm v2.16.1-0.20210420094828-a4ee02c38421+incompatible h1:rMPCv2n5WRUfnV6/Y8pC8RSvZzvsBOhO4lyCyBiGmGo=
+github.com/percona/pmm v2.16.1-0.20210420094828-a4ee02c38421+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/promconfig v0.2.1 h1:LBbCDSQRfy0aTHFJMgrVQIE2WvmPkMTkIoznTfBAvj8=
 github.com/percona/promconfig v0.2.1/go.mod h1:Y2uXi5QNk71+ceJHuI9poank+0S1kjxd3K105fXKVkg=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/percona-platform/saas v0.0.0-20210122115803-1b32ca1828e1 h1:VyKdL2wWY
 github.com/percona-platform/saas v0.0.0-20210122115803-1b32ca1828e1/go.mod h1:jJRyGMxxDJaSiU7AaHNS+8j1TFQQhX6lcYp8s0t8Knc=
 github.com/percona/pmm v2.15.2-0.20210405073023-614c31c2cf56+incompatible h1:UsroxqDiJaK+He77dk5lWH3jr5yA3kFpk/MvoOpTdbE=
 github.com/percona/pmm v2.15.2-0.20210405073023-614c31c2cf56+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
+github.com/percona/pmm v2.15.2-0.20210407110927-4b3756c1d2fe+incompatible h1:peECGcQ2rYt1eMtJJI4cYFSSysa+bNjDDPoNR4AiJWk=
+github.com/percona/pmm v2.15.2-0.20210407110927-4b3756c1d2fe+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/promconfig v0.2.1 h1:LBbCDSQRfy0aTHFJMgrVQIE2WvmPkMTkIoznTfBAvj8=
 github.com/percona/promconfig v0.2.1/go.mod h1:Y2uXi5QNk71+ceJHuI9poank+0S1kjxd3K105fXKVkg=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=

--- a/management/dbaas/xtra_db_cluster_test.go
+++ b/management/dbaas/xtra_db_cluster_test.go
@@ -31,12 +31,11 @@ func TestXtraDBClusterServer(t *testing.T) {
 				Name:                  "first-pxc-test",
 				Params: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParams{
 					ClusterSize: 3,
-					Proxysql: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParamsProxysql{
-						ComputeResources: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParamsProxysqlComputeResources{
+					Haproxy: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParamsHaproxy{
+						ComputeResources: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParamsHaproxyComputeResources{
 							CPUm:        500,
 							MemoryBytes: "1000000000",
 						},
-						DiskSize: "1000000000",
 					},
 					Pxc: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParamsPxc{
 						ComputeResources: &xtra_db_cluster.CreateXtraDBClusterParamsBodyParamsPxcComputeResources{
@@ -111,7 +110,7 @@ func TestXtraDBClusterServer(t *testing.T) {
 		xtraDBCluster, err := dbaasClient.Default.XtraDBCluster.GetXtraDBClusterCredentials(&getXtraDBClusterParamsParam)
 		assert.NoError(t, err)
 		assert.Equal(t, xtraDBCluster.Payload.ConnectionCredentials.Username, "root")
-		assert.Equal(t, xtraDBCluster.Payload.ConnectionCredentials.Host, "first-pxc-test-proxysql")
+		assert.Equal(t, xtraDBCluster.Payload.ConnectionCredentials.Host, "first-pxc-test-haproxy")
 		assert.Equal(t, xtraDBCluster.Payload.ConnectionCredentials.Port, int32(3306))
 		assert.NotEmpty(t, xtraDBCluster.Payload.ConnectionCredentials.Password)
 


### PR DESCRIPTION
We create two pxc clusters in tests, I changed one of them to use HAProxy instead of ProxySQL to make sure addition of HAProxy support was successful.